### PR TITLE
Make tests parallel-safe

### DIFF
--- a/core_test.go
+++ b/core_test.go
@@ -54,6 +54,7 @@ func (s CustomTestService) Stop(_ context.Context) error {
 }
 
 func TestCoreNoServiceError(t *testing.T) {
+	t.Parallel()
 	lcore := ablib.NewCore()
 	started, errChan := lcore.Start(context.Background())
 	require.Nil(t, started)
@@ -61,6 +62,7 @@ func TestCoreNoServiceError(t *testing.T) {
 }
 
 func TestCoreError(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
 	lcore := ablib.NewCore(CustomTestService{startErr: true, done: make(chan struct{})})
@@ -71,6 +73,7 @@ func TestCoreError(t *testing.T) {
 }
 
 func TestCoreContextDeadlineError(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
 	lcore := ablib.NewCore(CustomTestService{done: make(chan struct{})})
@@ -81,6 +84,7 @@ func TestCoreContextDeadlineError(t *testing.T) {
 }
 
 func TestCoreShutdown(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	lcore := ablib.NewCore(CustomTestService{startErr: false, done: make(chan struct{})})
@@ -92,6 +96,7 @@ func TestCoreShutdown(t *testing.T) {
 }
 
 func TestCoreShutdownError(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	lcore := ablib.NewCore(CustomTestService{startErr: false, stopErr: true, done: make(chan struct{})})
@@ -103,6 +108,7 @@ func TestCoreShutdownError(t *testing.T) {
 }
 
 func TestCoreShutdownContextDeadlineError(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	lcore := ablib.NewCore(CustomTestService{startErr: false, stopErr: true, done: make(chan struct{})})

--- a/http/authorization_test.go
+++ b/http/authorization_test.go
@@ -32,6 +32,7 @@ func createTestContext(role coremodels.GatewayRole) context.Context {
 }
 
 func TestIsAdminMiddleware_AllowsAdmin(t *testing.T) {
+	t.Parallel()
 	// Create a dummy admin user context.
 	ctx := createTestContext(coremodels.ADMIN)
 
@@ -68,6 +69,7 @@ func TestIsAdminMiddleware_AllowsAdmin(t *testing.T) {
 }
 
 func TestIsAdminMiddleware_RejectsNonAdmin(t *testing.T) {
+	t.Parallel()
 	// Create a dummy non-admin user context.
 	// Assuming a non-admin role is represented by something other than coremodels.ADMIN.
 	nonAdminRole := coremodels.GatewayRole("user")

--- a/http/cookie_test.go
+++ b/http/cookie_test.go
@@ -23,6 +23,7 @@ func (stubAuthRepo) AddRefreshToken(_ context.Context, _ string, _ string) error
 func (stubAuthRepo) RemoveRefreshToken(_ context.Context, _ string) error        { return nil }
 
 func TestCookieAuthMiddleware_NoCookie(t *testing.T) {
+	t.Parallel()
 	auth := NewCookieAuthHandler("secret", "session", "", 3600, stubAuthRepo{})
 	called := false
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -43,6 +44,7 @@ func TestCookieAuthMiddleware_NoCookie(t *testing.T) {
 }
 
 func TestCookieAuthLogout_NoCookie(t *testing.T) {
+	t.Parallel()
 	auth := NewCookieAuthHandler("secret", "session", "", 3600, stubAuthRepo{})
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()

--- a/http/jwt_test.go
+++ b/http/jwt_test.go
@@ -14,6 +14,7 @@ import (
 
 // TestValidateJWTMiddleware_MissingToken checks that a request with no token returns 401.
 func TestValidateJWTMiddleware_MissingToken(t *testing.T) {
+	t.Parallel()
 	pubKey := &rsa.PublicKey{}
 	middleware := ValidateJWTMiddleware(
 		&scrypto.JWK[*rsa.PrivateKey, *rsa.PublicKey]{PublicKey: pubKey},
@@ -38,6 +39,7 @@ func TestValidateJWTMiddleware_MissingToken(t *testing.T) {
 
 // TestValidateJWTMiddleware_InvalidToken ensures that an invalid token leads to a 401 response.
 func TestValidateJWTMiddleware_InvalidToken(t *testing.T) {
+	t.Parallel()
 	pubKey := &rsa.PublicKey{}
 	middleware := ValidateJWTMiddleware(
 		&scrypto.JWK[*rsa.PrivateKey, *rsa.PublicKey]{PublicKey: pubKey},
@@ -66,6 +68,7 @@ func TestValidateJWTMiddleware_InvalidToken(t *testing.T) {
 }
 
 func TestWithHeaderJWT_True(t *testing.T) {
+	t.Parallel()
 	config := middlewareConfig[*rsa.PrivateKey, *rsa.PublicKey]{}
 	opt := WithHeaderJWT[*rsa.PrivateKey, *rsa.PublicKey](true)
 	opt(&config)
@@ -76,6 +79,7 @@ func TestWithHeaderJWT_True(t *testing.T) {
 }
 
 func TestWithHeaderJWT_False(t *testing.T) {
+	t.Parallel()
 	conf := middlewareConfig[*rsa.PrivateKey, *rsa.PublicKey]{}
 	// Change config so that it is not already false.
 	conf.allowHeaderJWT = true
@@ -90,6 +94,7 @@ func TestWithHeaderJWT_False(t *testing.T) {
 
 // TestDefaultConfig_EmptyToken ensures that an empty token returns scrypto.ErrInvalidToken.
 func TestDefaultConfig_EmptyToken(t *testing.T) {
+	t.Parallel()
 	// Create a dummy jwk using a dummy rsa public key.
 	dummyJWK := &scrypto.JWK[*rsa.PrivateKey, *rsa.PublicKey]{
 		PublicKey: &rsa.PublicKey{},
@@ -107,6 +112,7 @@ func TestDefaultConfig_EmptyToken(t *testing.T) {
 
 // TestDefaultConfig_InvalidPurpose tests that a token with wrong purpose returns scrypto.ErrInvalidPurpose.
 func TestDefaultConfig_InvalidPurpose(t *testing.T) {
+	t.Parallel()
 	// Override with mock implementation
 	parseTokenFunc := func(tokenStr string) (*scrypto.JWT[*rsa.PrivateKey, *rsa.PublicKey], error) {
 		return nil, scrypto.ErrInvalidPurpose
@@ -125,6 +131,7 @@ func TestDefaultConfig_InvalidPurpose(t *testing.T) {
 
 // TestDefaultConfig_ValidToken verifies that a valid token is properly parsed.
 func TestDefaultConfig_ValidToken(t *testing.T) {
+	t.Parallel()
 	parseTokenFunc := func(tokenStr string) (*scrypto.JWT[*rsa.PrivateKey, *rsa.PublicKey], error) {
 		// If the token string is "valid", return a token with the correct purpose.
 		if tokenStr == "valid" {
@@ -151,6 +158,7 @@ func TestDefaultConfig_ValidToken(t *testing.T) {
 
 // Optional: A simple integration test using defaultConfig through the middleware.
 func TestValidateJWTMiddleware_WithValidToken(t *testing.T) {
+	t.Parallel()
 	parseTokenFunc := func(tokenStr string) (*scrypto.JWT[*rsa.PrivateKey, *rsa.PublicKey], error) {
 		if tokenStr == "valid-token" {
 			return &scrypto.JWT[*rsa.PrivateKey, *rsa.PublicKey]{

--- a/limit/rate_limiter_test.go
+++ b/limit/rate_limiter_test.go
@@ -76,6 +76,7 @@ func (fc *fakeClient) Set(ctx context.Context, key string, value any, expiration
 }
 
 func TestAllow_NewUser(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client := newFakeClient()
 	rl := NewRateLimiter(client, 1, 1, "test")
@@ -94,6 +95,7 @@ func TestAllow_NewUser(t *testing.T) {
 }
 
 func TestAllow_ReplenishToken(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client := newFakeClient()
 	// Use a burst of 5 tokens and a rate of 1 token per second.
@@ -138,6 +140,7 @@ func TestAllow_ReplenishToken(t *testing.T) {
 }
 
 func TestAllow_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client := newFakeClient()
 	rl := NewRateLimiter(client, 1, 2, "test")
@@ -155,6 +158,7 @@ func TestAllow_InvalidJSON(t *testing.T) {
 }
 
 func TestAllow_ForcedGetError(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	// Simulate Get error by forcing an error in fakeClient.
 	client := newFakeClient()
@@ -170,6 +174,7 @@ func TestAllow_ForcedGetError(t *testing.T) {
 }
 
 func TestAllow_ExhaustTokens(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client := newFakeClient()
 	rl := NewRateLimiter(client, 0.5, 3, "test") // refill rate 0.5 token per second, burst 3 tokens
@@ -208,6 +213,7 @@ func TestAllow_ExhaustTokens(t *testing.T) {
 	}
 }
 func TestAllow_Concurrent(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client := newFakeClient()
 	rl := NewRateLimiter(client, 1, 5, "test")
@@ -234,6 +240,7 @@ func TestAllow_Concurrent(t *testing.T) {
 }
 
 func TestAllow_EdgeCases(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	tests := []struct {
 		name      string
@@ -248,6 +255,7 @@ func TestAllow_EdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			client := newFakeClient()
 			rl := NewRateLimiter(client, tt.rate, tt.burst, "test")
 			if got := rl.Allow(ctx, "test-user"); got != tt.wantAllow {
@@ -257,6 +265,7 @@ func TestAllow_EdgeCases(t *testing.T) {
 	}
 }
 func TestAllow_FractionalTokens(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client := newFakeClient()
 	// 0.1 tokens per second, max 1 token
@@ -307,6 +316,7 @@ func TestAllow_FractionalTokens(t *testing.T) {
 }
 
 func TestAllow_EmptyUserID(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client := newFakeClient()
 	rl := NewRateLimiter(client, 1, 1, "test")

--- a/scrypto/bare_jwt_test.go
+++ b/scrypto/bare_jwt_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestIsActivationClaims(t *testing.T) {
+	t.Parallel()
 	claims := map[string]any{
 		ClaimKeyPurpose.String(): ClaimPurposeActivation.String(),
 	}
@@ -25,6 +26,7 @@ func TestIsActivationClaims(t *testing.T) {
 }
 
 func TestIsAuthenticationClaims(t *testing.T) {
+	t.Parallel()
 	claims := map[string]any{
 		ClaimKeyPurpose.String(): ClaimPurposeAuthentication.String(),
 	}
@@ -38,6 +40,7 @@ func TestIsAuthenticationClaims(t *testing.T) {
 }
 
 func TestIsRefreshClaims(t *testing.T) {
+	t.Parallel()
 	claims := map[string]any{
 		ClaimKeyPurpose.String(): ClaimPurposeRefresh.String(),
 	}
@@ -51,6 +54,7 @@ func TestIsRefreshClaims(t *testing.T) {
 }
 
 func TestEDDSASignAndParse(t *testing.T) {
+	t.Parallel()
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("failed to generate ed25519 key: %v", err)
@@ -94,6 +98,7 @@ func TestEDDSASignAndParse(t *testing.T) {
 }
 
 func TestRSASignAndParse(t *testing.T) {
+	t.Parallel()
 	rsaPriv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("failed to generate RSA key: %v", err)
@@ -137,6 +142,7 @@ func TestRSASignAndParse(t *testing.T) {
 }
 
 func TestGetStringClaim_ExistingKey(t *testing.T) {
+	t.Parallel()
 	claims := jwt.MapClaims{
 		"key1": "value1",
 	}
@@ -151,6 +157,7 @@ func TestGetStringClaim_ExistingKey(t *testing.T) {
 }
 
 func TestGetStringClaim_KeyNotFound(t *testing.T) {
+	t.Parallel()
 	claims := jwt.MapClaims{
 		"key1": "value1",
 	}
@@ -165,6 +172,7 @@ func TestGetStringClaim_KeyNotFound(t *testing.T) {
 }
 
 func TestGetStringClaim_NonStringValuePanics(t *testing.T) {
+	t.Parallel()
 	claims := jwt.MapClaims{
 		"key2": 123, // non-string value
 	}
@@ -178,6 +186,7 @@ func TestGetStringClaim_NonStringValuePanics(t *testing.T) {
 }
 
 func TestGetInt32Claim_ExistingKey(t *testing.T) {
+	t.Parallel()
 	// Set a claim value that is an integer.
 	claims := jwt.MapClaims{
 		"intClaim": int32(42),
@@ -193,6 +202,7 @@ func TestGetInt32Claim_ExistingKey(t *testing.T) {
 }
 
 func TestGetInt32Claim_KeyNotFound(t *testing.T) {
+	t.Parallel()
 	// If the key is not present, assume the default value 0 is returned.
 	claims := jwt.MapClaims{
 		"anotherKey": int32(100),
@@ -208,6 +218,7 @@ func TestGetInt32Claim_KeyNotFound(t *testing.T) {
 }
 
 func TestGetInt32Claim_NonIntValuePanics(t *testing.T) {
+	t.Parallel()
 	// If the claim value is not an integer, we expect a panic.
 	claims := jwt.MapClaims{
 		"intClaim": "not an integer",

--- a/scrypto/cryptlib_test.go
+++ b/scrypto/cryptlib_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestGenerateHash(t *testing.T) {
+	t.Parallel()
 	t.Run("successful password hashing", func(t *testing.T) {
 		password := "mySecurePassword123" //nolint:goconst
 		hash, err := Hash(password, bcrypt.DefaultCost)
@@ -57,6 +58,7 @@ func TestGenerateHash(t *testing.T) {
 }
 
 func TestGenerateRandomPassword(t *testing.T) {
+	t.Parallel()
 	t.Run("zero length", func(t *testing.T) {
 		pass, err := GenerateRandomPassword(0)
 		require.NoError(t, err)
@@ -82,6 +84,7 @@ func TestGenerateRandomPassword(t *testing.T) {
 }
 
 func TestSetSignedCookie_Success(t *testing.T) {
+	t.Parallel()
 	secretKey := []byte("myVerySecretKey123")
 	originalValue := "cookieValue123"
 	cookie := http.Cookie{
@@ -110,6 +113,7 @@ func TestSetSignedCookie_Success(t *testing.T) {
 }
 
 func TestSetSignedCookie_ValueTooLong(t *testing.T) {
+	t.Parallel()
 	secretKey := []byte("myVerySecretKey123")
 	// Generate a very long cookie value.
 	longValue := strings.Repeat("a", 5000)
@@ -125,6 +129,7 @@ func TestSetSignedCookie_ValueTooLong(t *testing.T) {
 }
 
 func TestGetSignedCookie_InvalidSignature(t *testing.T) {
+	t.Parallel()
 	secretKey := []byte("myVerySecretKey123")
 	// Generate a valid cookie.
 	validCookie := http.Cookie{
@@ -155,6 +160,7 @@ func TestGetSignedCookie_InvalidSignature(t *testing.T) {
 }
 
 func TestGetSignedCookie_MissingCookie(t *testing.T) {
+	t.Parallel()
 	secretKey := []byte("myVerySecretKey123")
 	// Create a request without any cookies.
 	req := httptest.NewRequest("GET", "http://example.com", nil)
@@ -166,6 +172,7 @@ func TestGetSignedCookie_MissingCookie(t *testing.T) {
 }
 
 func TestReadCookieValue_invalidBase64(t *testing.T) {
+	t.Parallel()
 	// Create a request with an invalid base64 cookie value.
 	req := httptest.NewRequest("GET", "http://example.com", nil)
 	cookie := &http.Cookie{
@@ -182,6 +189,7 @@ func TestReadCookieValue_invalidBase64(t *testing.T) {
 }
 
 func TestGetSignedCookie_InvalidValueTooShort(t *testing.T) {
+	t.Parallel()
 	secretKey := []byte("secretkey")
 	// Create an HTTP request.
 	req := httptest.NewRequest("GET", "http://example.com", nil)

--- a/scrypto/hash_test.go
+++ b/scrypto/hash_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestHash_CostTooLow(t *testing.T) {
+	t.Parallel()
 	password := "samplepassword"
 	invalidCost := bcrypt.MinCost - 1
 
@@ -20,6 +21,7 @@ func TestHash_CostTooLow(t *testing.T) {
 }
 
 func TestHash_CostTooHigh(t *testing.T) {
+	t.Parallel()
 	password := "samplepassword"
 	invalidCost := bcrypt.MaxCost + 1
 
@@ -33,6 +35,7 @@ func TestHash_CostTooHigh(t *testing.T) {
 }
 
 func TestHash_EmptyPassword(t *testing.T) {
+	t.Parallel()
 	var emptyPassword string
 	cost := bcrypt.MinCost
 
@@ -46,6 +49,7 @@ func TestHash_EmptyPassword(t *testing.T) {
 }
 
 func TestHash_Success(t *testing.T) {
+	t.Parallel()
 	password := "correcthorsebatterystaple"
 	cost := bcrypt.DefaultCost
 
@@ -65,6 +69,7 @@ func TestHash_Success(t *testing.T) {
 }
 
 func TestValidateHash_EmptyInput(t *testing.T) {
+	t.Parallel()
 	// Both password and hashedPassword are empty.
 	if ValidateHash("", "") {
 		t.Error("expected false when both password and hashedPassword are empty")
@@ -86,6 +91,7 @@ func TestValidateHash_EmptyInput(t *testing.T) {
 }
 
 func TestValidateHash_Invalid(t *testing.T) {
+	t.Parallel()
 	password := "correctpassword"
 	wrongPassword := "wrongpassword"
 
@@ -100,6 +106,7 @@ func TestValidateHash_Invalid(t *testing.T) {
 }
 
 func TestValidateHash_Valid(t *testing.T) {
+	t.Parallel()
 	password := "correctpassword"
 
 	hashed, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
@@ -112,6 +119,7 @@ func TestValidateHash_Valid(t *testing.T) {
 	}
 }
 func TestGenerateRandomPassword_Length(t *testing.T) {
+	t.Parallel()
 	desiredLength := 16
 	password, err := GenerateRandomPassword(desiredLength)
 	if err != nil {
@@ -123,6 +131,7 @@ func TestGenerateRandomPassword_Length(t *testing.T) {
 }
 
 func TestGenerateRandomPassword_Unique(t *testing.T) {
+	t.Parallel()
 	desiredLength := 16
 	password1, err := GenerateRandomPassword(desiredLength)
 	if err != nil {
@@ -138,6 +147,7 @@ func TestGenerateRandomPassword_Unique(t *testing.T) {
 }
 
 func TestGenerateRandomPassword_ZeroLength(t *testing.T) {
+	t.Parallel()
 	password, err := GenerateRandomPassword(0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/scrypto/http_test.go
+++ b/scrypto/http_test.go
@@ -15,6 +15,7 @@ import (
 
 // TestUserIDFromRequest_ValidToken checks that a valid token returns the correct user ID.
 func TestUserIDFromRequest_ValidToken(t *testing.T) {
+	t.Parallel()
 	pubKey := &rsa.PublicKey{}
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	// Set a cookie "token" with value "valid".
@@ -49,6 +50,7 @@ func UserIDFromRequest(req *http.Request, pubKey *rsa.PublicKey) (any, any) {
 
 // TestUserIDFromRequest_MissingToken verifies that when there is no token in the request, an error is returned.
 func TestUserIDFromRequest_MissingToken(t *testing.T) {
+	t.Parallel()
 	pubKey := &rsa.PublicKey{}
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	// Do not set any cookie or header.
@@ -61,6 +63,7 @@ func TestUserIDFromRequest_MissingToken(t *testing.T) {
 
 // TestUserIDFromRequest_NilToken simulates the case when ParseAuthToken returns a nil token.
 func TestUserIDFromRequest_NilToken(t *testing.T) {
+	t.Parallel()
 	pubKey := &rsa.PublicKey{}
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	// Set a cookie "token" with a value that will simulate a nil token.
@@ -77,6 +80,7 @@ func TestUserIDFromRequest_NilToken(t *testing.T) {
 
 // TestUserIDFromRequest_EmptyUID verifies that if the token has an empty UID, an error is returned.
 func TestUserIDFromRequest_EmptyUID(t *testing.T) {
+	t.Parallel()
 	pubKey := &rsa.PublicKey{}
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	// Set a cookie "token" with a value that yields an empty UID.
@@ -111,6 +115,7 @@ func ParseRefreshToken(tokenStr string, secretKey *rsa.PublicKey) (*JWT, error) 
 
 // TestRefreshTokenFromRequest_ValidTokenFromCookie checks that a valid refresh token in a cookie is parsed correctly.
 func TestRefreshTokenFromRequest_ValidTokenFromCookie(t *testing.T) {
+	t.Parallel()
 	secretKey := &rsa.PublicKey{}
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.AddCookie(&http.Cookie{
@@ -171,6 +176,7 @@ func RefreshTokenFromRequest(req *http.Request, secretKey *rsa.PublicKey) (*JWT,
 
 // TestRefreshTokenFromRequest_ValidTokenFromBody verifies that a valid refresh token in the JSON body is parsed correctly.
 func TestRefreshTokenFromRequest_ValidTokenFromBody(t *testing.T) {
+	t.Parallel()
 	secretKey := &rsa.PublicKey{}
 	bodyMap := map[string]string{"refresh_token": "valid"}
 	bodyBytes, _ := json.Marshal(bodyMap)
@@ -191,6 +197,7 @@ func TestRefreshTokenFromRequest_ValidTokenFromBody(t *testing.T) {
 
 // TestRefreshTokenFromRequest_MissingToken checks that when no refresh token is provided, an error is returned.
 func TestRefreshTokenFromRequest_MissingToken(t *testing.T) {
+	t.Parallel()
 	secretKey := &rsa.PublicKey{}
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	// No cookie and empty body.
@@ -202,6 +209,7 @@ func TestRefreshTokenFromRequest_MissingToken(t *testing.T) {
 
 // TestRefreshTokenFromRequest_InvalidJSON checks that a malformed JSON in body returns an error.
 func TestRefreshTokenFromRequest_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	secretKey := &rsa.PublicKey{}
 	invalidJSON := []byte(`{invalid json}`)
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(invalidJSON))
@@ -214,6 +222,7 @@ func TestRefreshTokenFromRequest_InvalidJSON(t *testing.T) {
 
 // TestRefreshTokenFromRequest_InvalidToken ensures that an invalid refresh token causes an error.
 func TestRefreshTokenFromRequest_InvalidToken(t *testing.T) {
+	t.Parallel()
 	secretKey := &rsa.PublicKey{}
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	// Set an invalid refresh token in cookie.
@@ -230,6 +239,7 @@ func TestRefreshTokenFromRequest_InvalidToken(t *testing.T) {
 
 // TestAuthTokenStrFromRequest_TokenFromCookie checks that the token is correctly returned from a non-empty cookie.
 func TestAuthTokenStrFromRequest_TokenFromCookie(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	expectedToken := "cookieToken"
 	req.AddCookie(&http.Cookie{
@@ -249,6 +259,7 @@ func TestAuthTokenStrFromRequest_TokenFromCookie(t *testing.T) {
 // TestAuthTokenStrFromRequest_EmptyCookieUsesHeader verifies that if the cookie value is empty,
 // the token is retrieved from the Authorization header.
 func TestAuthTokenStrFromRequest_EmptyCookieUsesHeader(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	// Set an empty token cookie.
 	req.AddCookie(&http.Cookie{
@@ -271,6 +282,7 @@ func TestAuthTokenStrFromRequest_EmptyCookieUsesHeader(t *testing.T) {
 // TestAuthTokenStrFromRequest_NoCookieUsesHeader checks that when no cookie is present,
 // the token is retrieved from the Authorization header.
 func TestAuthTokenStrFromRequest_NoCookieUsesHeader(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	expectedToken := "headerOnlyToken"
 	req.Header.Set("Authorization", "Bearer "+expectedToken)
@@ -286,6 +298,7 @@ func TestAuthTokenStrFromRequest_NoCookieUsesHeader(t *testing.T) {
 
 // TestAuthTokenStrFromRequest_MissingToken verifies that an error is returned when both cookie and header are missing.
 func TestAuthTokenStrFromRequest_MissingToken(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
 	token, err := scrypto.AuthTokenStrFromRequest(req)

--- a/scrypto/jwt_test.go
+++ b/scrypto/jwt_test.go
@@ -19,6 +19,7 @@ var (
 )
 
 func TestNewJWT(t *testing.T) {
+	t.Parallel()
 	uid := uuid.NewString()
 	companyID := uuid.NewString()
 
@@ -32,6 +33,7 @@ func TestNewJWT(t *testing.T) {
 }
 
 func TestParseToken(t *testing.T) {
+	t.Parallel()
 	uid := uuid.NewString()
 	companyID := uuid.NewString()
 
@@ -54,6 +56,7 @@ func TestParseToken(t *testing.T) {
 }
 
 func TestSignED25519(t *testing.T) {
+	t.Parallel()
 	uid := uuid.NewString()
 	companyID := uuid.NewString()
 
@@ -124,6 +127,7 @@ func generateRSAKey(_ *testing.T) (*rsa.PrivateKey, *rsa.PublicKey) {
 }
 
 func TestSignRSA(t *testing.T) {
+	t.Parallel()
 	uid := uuid.NewString()
 	companyID := uuid.NewString()
 
@@ -182,6 +186,7 @@ func TestSignRSA(t *testing.T) {
 }
 
 func TestValidateContextGRPC(t *testing.T) {
+	t.Parallel()
 	rsaPriv, rsaPub := generateRSAKey(t)
 
 	t.Run("missing metadata", func(t *testing.T) {
@@ -219,6 +224,7 @@ func TestValidateContextGRPC(t *testing.T) {
 	})
 }
 func TestParseRefreshToken(t *testing.T) {
+	t.Parallel()
 	// Generate an RSA key pair for testing.
 	rsaPriv, rsaPub := generateRSAKey(t)
 
@@ -282,6 +288,7 @@ func TestParseRefreshToken(t *testing.T) {
 
 // TestParseAuthTokenValid tests parsing a valid JWT token.
 func TestParseAuthTokenValid(t *testing.T) {
+	t.Parallel()
 	// Generate a new uid and companyID.
 	uid := uuid.NewString()
 	companyID := uuid.NewString()
@@ -310,6 +317,7 @@ func TestParseAuthTokenValid(t *testing.T) {
 
 // TestParseAuthTokenInvalid tests that parsing an invalid token returns an error.
 func TestParseAuthTokenInvalid(t *testing.T) {
+	t.Parallel()
 	// Prepare a public key JWK.
 	jwkPub := &JWK[ed25519.PrivateKey, ed25519.PublicKey]{PublicKey: publicED25519Key, Kid: "test-key"}
 

--- a/scrypto/key_gen_test.go
+++ b/scrypto/key_gen_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestGenerateED25519Keys(t *testing.T) {
+	t.Parallel()
 	privateKey, publicKey, err := GenerateED25519Keys()
 	if err != nil {
 		t.Fatalf("GenerateED25519Keys returned error: %v", err)
@@ -31,6 +32,7 @@ func TestGenerateED25519Keys(t *testing.T) {
 }
 
 func TestGenerateRSAKeys(t *testing.T) {
+	t.Parallel()
 	bits := 2048
 	privateKey, publicKey, err := GenerateRSAKeys(bits)
 	if err != nil {

--- a/store/mongo_options_test.go
+++ b/store/mongo_options_test.go
@@ -48,6 +48,7 @@ func setupTestContainer(t *testing.T) (*internal.Container, uint16, error) {
 }
 
 func TestNewMongoClient(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	container, port, err := setupTestContainer(t)
 	assert.NoError(t, err)
@@ -102,6 +103,7 @@ func TestNewMongoClient(t *testing.T) {
 }
 
 func TestMongoClientOperations(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	container, port, err := setupTestContainer(t)
 	assert.NoError(t, err)
@@ -174,6 +176,7 @@ func TestMongoClientOperations(t *testing.T) {
 }
 
 func TestMongoClientErrors(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client := &MongoClient{} // nil client
 

--- a/store/redis_options_test.go
+++ b/store/redis_options_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestSetSuccess(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Create a redis mock client and assign it to our RedisClient.
@@ -38,6 +39,7 @@ func TestSetSuccess(t *testing.T) {
 }
 
 func TestSetWithoutInitialization(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Create a RedisClient with a nil Client.
@@ -54,6 +56,7 @@ func TestSetWithoutInitialization(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Test Close when Client is nil.
@@ -82,6 +85,7 @@ func TestClose(t *testing.T) {
 }
 
 func TestNewRedisClient_InvalidAddress(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Using an invalid address, NewRedisClient should return an error.


### PR DESCRIPTION
## Summary
- enable `t.Parallel()` for tests that do not share state
- keep config and mongo subtests sequential to avoid conflicts

## Testing
- `go test ./... -race` *(fails: Forbidden when downloading go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68524f22e1808325acda60f5fc36efac