### PR TITLE
Add GitHub workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Go Tests
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      docker:
+        image: docker:24.0.2-dind
+        options: >-
+          --privileged
+          --tmpfs /var/lib/docker:exec
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - name: Run Tests
+        run: make test


### PR DESCRIPTION
## Summary
- add GitHub workflow to run Go tests

## Testing
- `make test` *(fails: downloading go toolchain blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852536336c88325893ff4ef444eacdb